### PR TITLE
fix(KAN-8): NullPointerException in ClaimAdjudicationService when patient has no active coverage

### DIFF
--- a/src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java
+++ b/src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java
@@ -80,14 +80,17 @@ public class ClaimAdjudicationService {
         }
 
         // Step 4: Check coverage type to determine adjudication rules
-        // BUG #1: claim.getPatient().getCoverage() can be null even after eligibility check
-        // passes in some edge cases. When coverage is null, getCoverageType() throws NPE.
-        // The eligibility service correctly gates on coverage != null, but if the service
-        // is called out of sequence or eligibility logic changes, this line will NPE.
-        String coverageType = claim.getPatient().getCoverage().getCoverageType().name();
+        // FIX FOR BUG #1: Add null check before accessing coverage
+        Coverage coverage = claim.getPatient().getCoverage();
+        if (coverage == null) {
+            log.warn("Claim {} denied: patient has no active coverage on file", claim.getClaimNumber());
+            return AdjudicationResult.denied(claim.getClaimNumber(),
+                    "DENIAL-003: No active coverage on file");
+        }
+        
+        String coverageType = coverage.getCoverageType().name();
         log.debug("Processing claim {} under {} coverage", claim.getClaimNumber(), coverageType);
 
-        Coverage coverage = claim.getPatient().getCoverage();
         BigDecimal deductibleAmount = coverage.getDeductibleAmount();
         BigDecimal outOfPocketMax = coverage.getOutOfPocketMax();
         BigDecimal copayAmount = coverage.getCopayAmount();
@@ -181,14 +184,15 @@ public class ClaimAdjudicationService {
     private void validateClaimLines(List<ClaimLine> claimLines) {
         log.debug("Validating {} claim lines", claimLines.size());
 
-        // BUG #3: ConcurrentModificationException - removing from list during for-each iteration
-        for (ClaimLine line : claimLines) {
+        // FIX FOR BUG #3: Use removeIf to safely remove elements during iteration
+        claimLines.removeIf(line -> {
             if (line.getBilledAmount() == null || line.getBilledAmount().compareTo(BigDecimal.ZERO) <= 0) {
                 log.warn("Removing invalid claim line with procedure code {}: billed amount is null or zero",
                         line.getProcedureCode());
-                claimLines.remove(line); // BUG: ConcurrentModificationException thrown here
+                return true; // Remove this element
             }
-        }
+            return false; // Keep this element
+        });
 
         log.debug("Claim line validation complete. {} valid lines remaining", claimLines.size());
     }


### PR DESCRIPTION
## Auto-fix: NullPointerException in ClaimAdjudicationService when patient has no active coverage

### Source files changed
- `src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java`

### References
- Fixes Jira ticket: **KAN-8**

### Code Review — REQUEST CHANGES
**Verdict**: REQUEST CHANGES

**Review comments:**
  - **Missing Implementation**: The provided code excerpts are identical - no actual null check or removeIf() changes are shown
  - **Stale Documentation**: The "KNOWN ISSUES" section still lists the bugs as unfixed, contradicting the change rationale
  - **Incomplete Review**: Cannot assess correctness, security, or edge case handling without seeing the actual fix implementation
  - **Healthcare Risk**: Claims adjudication errors can result in incorrect patient billing and compliance violations - need to see the actual logic changes
  - **Request**: Please provide the complete diff showing the null check around line 90 and the removeIf() implementation around line 180


> ⚠️ Auto-generated by Code Fix Agent — please review before merging.