### PR TITLE
fix(KAN-10): ConcurrentModificationException crashes batch claim processing when invalid claim lines present

### DIFF
--- a/src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java
+++ b/src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java
@@ -12,6 +12,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -170,23 +171,23 @@ public class ClaimAdjudicationService {
      * Validates claim lines by removing any lines with null or zero/negative billed amounts.
      * Invalid lines are removed before adjudication proceeds.
      *
-     * BUG #3: This method uses a for-each loop and calls List.remove() inside the loop body.
-     * Modifying a collection while iterating over it with an enhanced for-each loop
-     * throws a ConcurrentModificationException at runtime. The correct approach is to
-     * use an Iterator with iterator.remove(), or collect lines to remove in a separate
-     * list and call removeAll() after the loop.
+     * BUG #3 FIXED: This method previously used a for-each loop and called List.remove() inside 
+     * the loop body, which threw ConcurrentModificationException. Now uses Iterator.remove() 
+     * which is safe for concurrent modification during iteration.
      *
      * @param claimLines the list of claim lines to validate (modified in place)
      */
     private void validateClaimLines(List<ClaimLine> claimLines) {
         log.debug("Validating {} claim lines", claimLines.size());
 
-        // BUG #3: ConcurrentModificationException - removing from list during for-each iteration
-        for (ClaimLine line : claimLines) {
+        // BUG #3 FIXED: Use Iterator pattern for safe removal during iteration
+        Iterator<ClaimLine> iterator = claimLines.iterator();
+        while (iterator.hasNext()) {
+            ClaimLine line = iterator.next();
             if (line.getBilledAmount() == null || line.getBilledAmount().compareTo(BigDecimal.ZERO) <= 0) {
                 log.warn("Removing invalid claim line with procedure code {}: billed amount is null or zero",
                         line.getProcedureCode());
-                claimLines.remove(line); // BUG: ConcurrentModificationException thrown here
+                iterator.remove(); // Safe removal using Iterator
             }
         }
 


### PR DESCRIPTION
## Auto-fix: ConcurrentModificationException crashes batch claim processing when invalid claim lines present

### Source files changed
- `src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java`

### References
- Fixes Jira ticket: **KAN-10**

### Code Review — REQUEST CHANGES
**Verdict**: REQUEST CHANGES

**Review comments:**
  - Only see import addition (`java.util.Iterator`) but not the actual loop modification in validateClaimLines method
  - Need to see the complete method implementation to verify proper Iterator.remove() usage
  - Ensure invalid claim line removals are logged for audit trail (healthcare compliance requirement)
  - Verify that removing invalid lines doesn't affect downstream processing or financial calculations
  - The KNOWN ISSUES comment still lists Bug #3 as unfixed - should be updated to reflect resolution


> ⚠️ Auto-generated by Code Fix Agent — please review before merging.