### PR TITLE
fix(KAN-10): ConcurrentModificationException crashes batch claim processing when invalid claim lines present

### DIFF
--- a/src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java
+++ b/src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java
@@ -12,6 +12,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -181,12 +182,14 @@ public class ClaimAdjudicationService {
     private void validateClaimLines(List<ClaimLine> claimLines) {
         log.debug("Validating {} claim lines", claimLines.size());
 
-        // BUG #3: ConcurrentModificationException - removing from list during for-each iteration
-        for (ClaimLine line : claimLines) {
+        // FIX for BUG #3: Use Iterator to safely remove items during iteration
+        Iterator<ClaimLine> iterator = claimLines.iterator();
+        while (iterator.hasNext()) {
+            ClaimLine line = iterator.next();
             if (line.getBilledAmount() == null || line.getBilledAmount().compareTo(BigDecimal.ZERO) <= 0) {
                 log.warn("Removing invalid claim line with procedure code {}: billed amount is null or zero",
                         line.getProcedureCode());
-                claimLines.remove(line); // BUG: ConcurrentModificationException thrown here
+                iterator.remove(); // Safe removal using iterator
             }
         }
 


### PR DESCRIPTION
## Auto-fix: ConcurrentModificationException crashes batch claim processing when invalid claim lines present

### Source files changed
- `src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java`

### References
- Fixes Jira ticket: **KAN-10**

### Code Review — REQUEST CHANGES
**Verdict**: REQUEST CHANGES

**Review comments:**
  - **Incomplete Fix**: Only see the import addition; need to see the actual `validateClaimLines` method around line 180 where the iterator.remove() should be implemented
  - **Documentation Issue**: The "KNOWN ISSUES" comment still references Bug #3 as unfixed, but this PR claims to fix it
  - **Missing Context**: Cannot verify the Iterator is used correctly without seeing the iteration logic that was causing the concurrent modification
  - **Potential PHI Risk**: In healthcare claims processing, ensure invalid claim lines are logged appropriately without exposing PHI in error messages
  - **Testing Gap**: Need unit tests demonstrating the fix works with concurrent modifications during batch processing


> Auto-generated by Developer Agent — please review before merging.