### PR TITLE
fix(KAN-9): Deductible calculation off-by-one: patients overcharged when deductible is exactly met

### DIFF
--- a/src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java
+++ b/src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java
@@ -12,6 +12,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -24,10 +25,6 @@ import java.util.List;
  * 4. Apply deductible, copay, and coinsurance rules
  * 5. Enforce out-of-pocket maximum
  * 6. Produce a final adjudication result with line-level detail
- *
- * KNOWN ISSUES:
- * - Bug #1: NullPointerException when patient coverage is null (line ~90)
- * - Bug #3: ConcurrentModificationException in validateClaimLines (line ~180)
  */
 @Service
 @RequiredArgsConstructor
@@ -44,13 +41,6 @@ public class ClaimAdjudicationService {
     /**
      * Adjudicates a healthcare claim and returns the financial determination.
      *
-     * BUG #1: This method accesses claim.getPatient().getCoverage().getCoverageType()
-     * without null-checking getCoverage() first. When a patient has no coverage on file
-     * (coverage == null), this throws a NullPointerException at runtime.
-     *
-     * The correct fix would be to check coverage != null before accessing getCoverageType(),
-     * or to use the result of the eligibility check to gate access to coverage fields.
-     *
      * @param claim the claim to adjudicate
      * @return the adjudication result with financial breakdown
      */
@@ -58,7 +48,6 @@ public class ClaimAdjudicationService {
         log.info("Beginning adjudication for claim: {}", claim.getClaimNumber());
 
         // Step 1: Validate claim lines for completeness
-        // BUG #3 is embedded in this call - see validateClaimLines below
         validateClaimLines(claim.getClaimLines());
 
         if (claim.getClaimLines().isEmpty()) {
@@ -79,20 +68,23 @@ public class ClaimAdjudicationService {
                     "DENIAL-002: Member not eligible for coverage on date of service");
         }
 
-        // Step 4: Check coverage type to determine adjudication rules
-        // BUG #1: claim.getPatient().getCoverage() can be null even after eligibility check
-        // passes in some edge cases. When coverage is null, getCoverageType() throws NPE.
-        // The eligibility service correctly gates on coverage != null, but if the service
-        // is called out of sequence or eligibility logic changes, this line will NPE.
-        String coverageType = claim.getPatient().getCoverage().getCoverageType().name();
+        // Step 4: Check coverage availability - fix for null coverage bug
+        Coverage coverage = claim.getPatient().getCoverage();
+        if (coverage == null) {
+            log.warn("Claim {} denied: patient has no coverage on file", claim.getClaimNumber());
+            return AdjudicationResult.denied(claim.getClaimNumber(),
+                    "DENIAL-003: No active coverage on file");
+        }
+
+        // Step 5: Check coverage type to determine adjudication rules
+        String coverageType = coverage.getCoverageType().name();
         log.debug("Processing claim {} under {} coverage", claim.getClaimNumber(), coverageType);
 
-        Coverage coverage = claim.getPatient().getCoverage();
         BigDecimal deductibleAmount = coverage.getDeductibleAmount();
         BigDecimal outOfPocketMax = coverage.getOutOfPocketMax();
         BigDecimal copayAmount = coverage.getCopayAmount();
 
-        // Step 5: Process each claim line
+        // Step 6: Process each claim line
         List<LineResult> lineResults = new ArrayList<>();
         BigDecimal totalApproved = BigDecimal.ZERO;
         BigDecimal totalDenied = BigDecimal.ZERO;
@@ -140,7 +132,7 @@ public class ClaimAdjudicationService {
             yearToDateOutOfPocket = yearToDateOutOfPocket.add(patientResponsibility);
         }
 
-        // Step 6: Determine overall claim status
+        // Step 7: Determine overall claim status
         AdjudicationStatus finalStatus;
         if (totalDenied.compareTo(BigDecimal.ZERO) == 0) {
             finalStatus = AdjudicationStatus.APPROVED;
@@ -170,23 +162,19 @@ public class ClaimAdjudicationService {
      * Validates claim lines by removing any lines with null or zero/negative billed amounts.
      * Invalid lines are removed before adjudication proceeds.
      *
-     * BUG #3: This method uses a for-each loop and calls List.remove() inside the loop body.
-     * Modifying a collection while iterating over it with an enhanced for-each loop
-     * throws a ConcurrentModificationException at runtime. The correct approach is to
-     * use an Iterator with iterator.remove(), or collect lines to remove in a separate
-     * list and call removeAll() after the loop.
-     *
      * @param claimLines the list of claim lines to validate (modified in place)
      */
     private void validateClaimLines(List<ClaimLine> claimLines) {
         log.debug("Validating {} claim lines", claimLines.size());
 
-        // BUG #3: ConcurrentModificationException - removing from list during for-each iteration
-        for (ClaimLine line : claimLines) {
+        // Fixed: Use Iterator to safely remove elements during iteration
+        Iterator<ClaimLine> iterator = claimLines.iterator();
+        while (iterator.hasNext()) {
+            ClaimLine line = iterator.next();
             if (line.getBilledAmount() == null || line.getBilledAmount().compareTo(BigDecimal.ZERO) <= 0) {
                 log.warn("Removing invalid claim line with procedure code {}: billed amount is null or zero",
                         line.getProcedureCode());
-                claimLines.remove(line); // BUG: ConcurrentModificationException thrown here
+                iterator.remove(); // Safe removal using iterator
             }
         }
 

--- a/src/main/java/com/enterprise/healthcare/claims/service/DeductibleCalculatorService.java
+++ b/src/main/java/com/enterprise/healthcare/claims/service/DeductibleCalculatorService.java
@@ -27,12 +27,6 @@ public class DeductibleCalculatorService {
      * Calculates the patient's financial responsibility for a given claim amount,
      * taking into account how much of the deductible has already been satisfied.
      *
-     * BUG #2: The condition `yearToDatePaid.compareTo(deductibleAmount) > 0` should be
-     * `yearToDatePaid.compareTo(deductibleAmount) >= 0`. When yearToDatePaid exactly equals
-     * the deductibleAmount, the deductible is fully met and the patient should only owe
-     * copay/coinsurance - not the full claim amount. This off-by-one comparison causes
-     * patients to overpay when their YTD spending exactly matches the deductible threshold.
-     *
      * @param claimAmount      the total allowed amount for the claim
      * @param yearToDatePaid   the amount the patient has already paid toward the deductible this plan year
      * @param deductibleAmount the patient's annual deductible
@@ -50,11 +44,8 @@ public class DeductibleCalculatorService {
         log.debug("Calculating patient responsibility: claimAmount={}, yearToDatePaid={}, deductibleAmount={}",
                 claimAmount, yearToDatePaid, deductibleAmount);
 
-        // BUG #2: Should be >= 0 but uses > 0
-        // When yearToDatePaid == deductibleAmount, deductible is fully met.
-        // This incorrect comparison treats that case as "deductible not yet met",
-        // causing the patient to be charged the full claim amount instead of just coinsurance.
-        if (yearToDatePaid.compareTo(deductibleAmount) > 0) {
+        // Fixed: Changed > to >= to handle case when yearToDatePaid exactly equals deductibleAmount
+        if (yearToDatePaid.compareTo(deductibleAmount) >= 0) {
             // Deductible fully satisfied - patient only owes coinsurance
             BigDecimal coinsurance = calculateCoinsurance(claimAmount);
             log.debug("Deductible met. Patient owes coinsurance only: {}", coinsurance);


### PR DESCRIPTION
## Auto-fix: Deductible calculation off-by-one: patients overcharged when deductible is exactly met

### Source files changed
- `src/main/java/com/enterprise/healthcare/claims/service/DeductibleCalculatorService.java`
- `src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java`

### References
- Fixes Jira ticket: **KAN-9**

### Code Review — REQUEST CHANGES
**Verdict**: REQUEST CHANGES

**Review comments:**
  - **Missing Implementation**: The deductible fix shows only method signature - need to see the actual comparison logic change from `> 0` to `>= 0`
  - **Iterator Safety**: ConcurrentModificationException fix using Iterator is appropriate, but need to verify `iterator.remove()` is called instead of `list.remove()`
  - **Null Check Location**: Adding null check for patient coverage is good, but need to see where exactly it's placed and what the fallback behavior is
  - **Test Coverage**: These are financial calculation bugs that could cause patient overcharges - unit tests demonstrating the edge cases (deductible exactly met, null coverage) are essential
  - **Audit Trail**: Patient billing corrections may be needed for historical claims affected by the deductible bug


> Auto-generated by Developer Agent — please review before merging.