### PR TITLE
fix(KAN-10): ConcurrentModificationException crashes batch claim processing when invalid claim lines present

### DIFF
--- a/src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java
+++ b/src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java
@@ -170,25 +170,20 @@ public class ClaimAdjudicationService {
      * Validates claim lines by removing any lines with null or zero/negative billed amounts.
      * Invalid lines are removed before adjudication proceeds.
      *
-     * BUG #3: This method uses a for-each loop and calls List.remove() inside the loop body.
-     * Modifying a collection while iterating over it with an enhanced for-each loop
-     * throws a ConcurrentModificationException at runtime. The correct approach is to
-     * use an Iterator with iterator.remove(), or collect lines to remove in a separate
-     * list and call removeAll() after the loop.
-     *
      * @param claimLines the list of claim lines to validate (modified in place)
      */
     private void validateClaimLines(List<ClaimLine> claimLines) {
         log.debug("Validating {} claim lines", claimLines.size());
 
-        // BUG #3: ConcurrentModificationException - removing from list during for-each iteration
-        for (ClaimLine line : claimLines) {
+        // Fixed: Use removeIf to avoid ConcurrentModificationException
+        claimLines.removeIf(line -> {
             if (line.getBilledAmount() == null || line.getBilledAmount().compareTo(BigDecimal.ZERO) <= 0) {
                 log.warn("Removing invalid claim line with procedure code {}: billed amount is null or zero",
                         line.getProcedureCode());
-                claimLines.remove(line); // BUG: ConcurrentModificationException thrown here
+                return true;
             }
-        }
+            return false;
+        });
 
         log.debug("Claim line validation complete. {} valid lines remaining", claimLines.size());
     }


### PR DESCRIPTION
## Auto-fix: ConcurrentModificationException crashes batch claim processing when invalid claim lines present

### Source files changed
- `src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java`

### References
- Fixes Jira ticket: **KAN-10**

### Code Review — REQUEST CHANGES
**Verdict**: REQUEST CHANGES

**Review comments:**
  - **Missing Implementation**: Both "original" and "new" code excerpts are identical - the actual fix to validateClaimLines method is not shown
  - **Incomplete Review**: Cannot verify if removeIf() was properly implemented without seeing the modified validateClaimLines method around line 180
  - **Documentation Gap**: The "KNOWN ISSUES" comment still lists Bug #3 as unfixed, contradicting the change rationale
  - **Verification Needed**: Need to see the actual method transformation from problematic for-each iteration to safe removeIf() pattern
  - **Healthcare Context**: ConcurrentModificationException in batch processing could cause claim processing delays affecting patient care - fix verification is critical


> Auto-generated by Developer Agent — please review before merging.