### PR TITLE
fix(KAN-10): ConcurrentModificationException crashes batch claim processing when invalid claim lines present

### DIFF
--- a/src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java
+++ b/src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java
@@ -12,6 +12,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -181,12 +182,14 @@ public class ClaimAdjudicationService {
     private void validateClaimLines(List<ClaimLine> claimLines) {
         log.debug("Validating {} claim lines", claimLines.size());
 
-        // BUG #3: ConcurrentModificationException - removing from list during for-each iteration
-        for (ClaimLine line : claimLines) {
+        // FIXED BUG #3: Using Iterator to safely remove elements during iteration
+        Iterator<ClaimLine> iterator = claimLines.iterator();
+        while (iterator.hasNext()) {
+            ClaimLine line = iterator.next();
             if (line.getBilledAmount() == null || line.getBilledAmount().compareTo(BigDecimal.ZERO) <= 0) {
                 log.warn("Removing invalid claim line with procedure code {}: billed amount is null or zero",
                         line.getProcedureCode());
-                claimLines.remove(line); // BUG: ConcurrentModificationException thrown here
+                iterator.remove(); // Safe removal using iterator
             }
         }
 


### PR DESCRIPTION
## Auto-fix: ConcurrentModificationException crashes batch claim processing when invalid claim lines present

### Source files changed
- `src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java`

### References
- Fixes Jira ticket: **KAN-10**

### Code Review — REQUEST CHANGES
**Verdict**: REQUEST CHANGES

**Review comments:**
  - **Missing Implementation**: Only the Iterator import is visible; need to see the actual validateClaimLines method fix to verify ConcurrentModificationException is resolved
  - **Documentation Gap**: Known issues comment still lists "Bug #3: ConcurrentModificationException" - should be removed after fix is confirmed working
  - **Incomplete Review**: Cannot assess correctness, edge cases, or performance impact without seeing the modified iteration logic
  - **Security Concern**: Need to verify that removing invalid claim lines doesn't bypass required validation logging for audit trails (HIPAA compliance)
  - **Request**: Please provide the complete validateClaimLines method showing the Iterator.remove() implementation to complete the review


> Auto-generated by Developer Agent — please review before merging.