### PR TITLE
fix(KAN-8): NullPointerException in ClaimAdjudicationService when patient has no active coverage

### DIFF
--- a/src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java
+++ b/src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java
@@ -4,14 +4,15 @@ import com.enterprise.healthcare.claims.model.*;
 import com.enterprise.healthcare.claims.model.AdjudicationResult.AdjudicationStatus;
 import com.enterprise.healthcare.claims.model.AdjudicationResult.LineResult;
 import com.enterprise.healthcare.claims.model.Provider.NetworkStatus;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+lombok.RequiredArgsConstructor;
+lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -80,14 +81,17 @@ public class ClaimAdjudicationService {
         }
 
         // Step 4: Check coverage type to determine adjudication rules
-        // BUG #1: claim.getPatient().getCoverage() can be null even after eligibility check
-        // passes in some edge cases. When coverage is null, getCoverageType() throws NPE.
-        // The eligibility service correctly gates on coverage != null, but if the service
-        // is called out of sequence or eligibility logic changes, this line will NPE.
-        String coverageType = claim.getPatient().getCoverage().getCoverageType().name();
+        // BUG #1 FIX: Add null check for coverage before accessing coverageType
+        Coverage coverage = claim.getPatient().getCoverage();
+        if (coverage == null) {
+            log.warn("Claim {} denied: patient has no coverage on file", claim.getClaimNumber());
+            return AdjudicationResult.denied(claim.getClaimNumber(),
+                    "DENIAL-003: No active coverage on file");
+        }
+        
+        String coverageType = coverage.getCoverageType().name();
         log.debug("Processing claim {} under {} coverage", claim.getClaimNumber(), coverageType);
 
-        Coverage coverage = claim.getPatient().getCoverage();
         BigDecimal deductibleAmount = coverage.getDeductibleAmount();
         BigDecimal outOfPocketMax = coverage.getOutOfPocketMax();
         BigDecimal copayAmount = coverage.getCopayAmount();
@@ -181,12 +185,14 @@ public class ClaimAdjudicationService {
     private void validateClaimLines(List<ClaimLine> claimLines) {
         log.debug("Validating {} claim lines", claimLines.size());
 
-        // BUG #3: ConcurrentModificationException - removing from list during for-each iteration
-        for (ClaimLine line : claimLines) {
+        // BUG #3 FIX: Use Iterator to safely remove elements during iteration
+        Iterator<ClaimLine> iterator = claimLines.iterator();
+        while (iterator.hasNext()) {
+            ClaimLine line = iterator.next();
             if (line.getBilledAmount() == null || line.getBilledAmount().compareTo(BigDecimal.ZERO) <= 0) {
                 log.warn("Removing invalid claim line with procedure code {}: billed amount is null or zero",
                         line.getProcedureCode());
-                claimLines.remove(line); // BUG: ConcurrentModificationException thrown here
+                iterator.remove(); // Safe removal using iterator
             }
         }
 


### PR DESCRIPTION
## Auto-fix: NullPointerException in ClaimAdjudicationService when patient has no active coverage

### Source files changed
- `src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java`

### References
- Fixes Jira ticket: **KAN-8**

### Code Review — REQUEST CHANGES
**Verdict**: REQUEST CHANGES

**Review comments:**
  - **Missing Implementation**: The excerpts don't show lines ~90 or ~180 where the actual bugs occur, making it impossible to verify the fixes
  - **Import Issue**: There's a malformed import statement (`lombok.RequiredArgsConstructor;` missing `import`) that would cause compilation failure  
  - **Incomplete Coverage**: Without seeing the coverage null check logic, cannot verify HIPAA-compliant error handling for missing patient coverage scenarios
  - **Documentation Gap**: The "KNOWN ISSUES" comments should be removed if bugs are actually fixed, or updated to reflect current status
  - **Need Full Context**: Please provide the complete method implementations where the NPE and ConcurrentModificationException fixes were applied to properly assess correctness and security


> Auto-generated by Developer Agent — please review before merging.