### PR TITLE
fix(KAN-10): ConcurrentModificationException crashes batch claim processing when invalid claim lines present

### DIFF
--- a/src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java
+++ b/src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java
@@ -12,6 +12,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -27,7 +28,7 @@ import java.util.List;
  *
  * KNOWN ISSUES:
  * - Bug #1: NullPointerException when patient coverage is null (line ~90)
- * - Bug #3: ConcurrentModificationException in validateClaimLines (line ~180)
+ * - Bug #3: ConcurrentModificationException in validateClaimLines (line ~180) - FIXED
  */
 @Service
 @RequiredArgsConstructor
@@ -181,12 +182,14 @@ public class ClaimAdjudicationService {
     private void validateClaimLines(List<ClaimLine> claimLines) {
         log.debug("Validating {} claim lines", claimLines.size());
 
-        // BUG #3: ConcurrentModificationException - removing from list during for-each iteration
-        for (ClaimLine line : claimLines) {
+        // FIXED BUG #3: Use Iterator.remove() to safely modify collection during iteration
+        Iterator<ClaimLine> iterator = claimLines.iterator();
+        while (iterator.hasNext()) {
+            ClaimLine line = iterator.next();
             if (line.getBilledAmount() == null || line.getBilledAmount().compareTo(BigDecimal.ZERO) <= 0) {
                 log.warn("Removing invalid claim line with procedure code {}: billed amount is null or zero",
                         line.getProcedureCode());
-                claimLines.remove(line); // BUG: ConcurrentModificationException thrown here
+                iterator.remove(); // Safe removal using iterator
             }
         }
 


### PR DESCRIPTION
## Auto-fix: ConcurrentModificationException crashes batch claim processing when invalid claim lines present

### Source files changed
- `src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java`

### References
- Fixes Jira ticket: **KAN-10**

### Code Review — REQUEST CHANGES
**Verdict**: REQUEST CHANGES

**Review comments:**
  - **Incomplete Review**: The provided code only shows imports and class declaration - need to see the actual `validateClaimLines` method implementation where the Iterator fix was applied
  - **Positive Direction**: Adding `Iterator` import suggests correct approach to fix ConcurrentModificationException
  - **Documentation Update**: Good practice updating the comment to reflect the bug fix
  - **Missing Context**: Cannot verify if the Iterator.remove() is properly implemented or if invalid claim lines are being logged for audit trails (critical for healthcare compliance)
  - **Need Full Method**: Please provide the complete `validateClaimLines` method to verify the fix handles edge cases like empty collections and maintains proper PHI logging


> Auto-generated by Developer Agent — please review before merging.