### PR TITLE
fix(KAN-8): NullPointerException in ClaimAdjudicationService when patient has no active coverage

### DIFF
--- a/src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java
+++ b/src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java
@@ -79,15 +79,18 @@ public class ClaimAdjudicationService {
                     "DENIAL-002: Member not eligible for coverage on date of service");
         }
 
+        // BUG #1 FIX: Check if coverage is null before accessing getCoverageType()
+        Coverage coverage = claim.getPatient().getCoverage();
+        if (coverage == null) {
+            log.warn("Claim {} denied: patient has no coverage record on file", claim.getClaimNumber());
+            return AdjudicationResult.denied(claim.getClaimNumber(),
+                    "DENIAL-003: No active coverage on file");
+        }
+
         // Step 4: Check coverage type to determine adjudication rules
-        // BUG #1: claim.getPatient().getCoverage() can be null even after eligibility check
-        // passes in some edge cases. When coverage is null, getCoverageType() throws NPE.
-        // The eligibility service correctly gates on coverage != null, but if the service
-        // is called out of sequence or eligibility logic changes, this line will NPE.
-        String coverageType = claim.getPatient().getCoverage().getCoverageType().name();
+        String coverageType = coverage.getCoverageType().name();
         log.debug("Processing claim {} under {} coverage", claim.getClaimNumber(), coverageType);
 
-        Coverage coverage = claim.getPatient().getCoverage();
         BigDecimal deductibleAmount = coverage.getDeductibleAmount();
         BigDecimal outOfPocketMax = coverage.getOutOfPocketMax();
         BigDecimal copayAmount = coverage.getCopayAmount();
@@ -181,14 +184,15 @@ public class ClaimAdjudicationService {
     private void validateClaimLines(List<ClaimLine> claimLines) {
         log.debug("Validating {} claim lines", claimLines.size());
 
-        // BUG #3: ConcurrentModificationException - removing from list during for-each iteration
-        for (ClaimLine line : claimLines) {
+        // BUG #3 FIX: Use removeIf instead of for-each loop with remove()
+        claimLines.removeIf(line -> {
             if (line.getBilledAmount() == null || line.getBilledAmount().compareTo(BigDecimal.ZERO) <= 0) {
                 log.warn("Removing invalid claim line with procedure code {}: billed amount is null or zero",
                         line.getProcedureCode());
-                claimLines.remove(line); // BUG: ConcurrentModificationException thrown here
+                return true;
             }
-        }
+            return false;
+        });
 
         log.debug("Claim line validation complete. {} valid lines remaining", claimLines.size());
     }


### PR DESCRIPTION
## Auto-fix: NullPointerException in ClaimAdjudicationService when patient has no active coverage

### Source files changed
- `src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java`

### References
- Fixes Jira ticket: **KAN-8**

### Code Review — REQUEST CHANGES
**Verdict**: REQUEST CHANGES

**Review comments:**
  - **Missing Implementation**: Both "original" and "new" code snippets are identical - the actual null check for coverage and removeIf() replacement are not visible
  - **Incomplete Review**: Cannot verify the fixes for Bug #1 (NPE on null coverage) or Bug #3 (ConcurrentModificationException) without seeing the changed methods
  - **Documentation Inconsistency**: The javadoc still lists the same "KNOWN ISSUES" that were supposedly fixed
  - **Healthcare Impact**: Cannot assess HIPAA compliance or claim processing correctness without seeing the actual adjudication logic changes
  - **Need Complete Diff**: Please provide the full method implementations showing the null checks and collection modification fixes


> Auto-generated by Developer Agent — please review before merging.