### PR TITLE
fix(KAN-10): ConcurrentModificationException crashes batch claim processing when invalid claim lines present

### DIFF
--- a/src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java
+++ b/src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java
@@ -12,6 +12,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -181,12 +182,14 @@ public class ClaimAdjudicationService {
     private void validateClaimLines(List<ClaimLine> claimLines) {
         log.debug("Validating {} claim lines", claimLines.size());
 
-        // BUG #3: ConcurrentModificationException - removing from list during for-each iteration
-        for (ClaimLine line : claimLines) {
+        // BUG #3 FIX: Use Iterator instead of for-each loop to avoid ConcurrentModificationException
+        Iterator<ClaimLine> iterator = claimLines.iterator();
+        while (iterator.hasNext()) {
+            ClaimLine line = iterator.next();
             if (line.getBilledAmount() == null || line.getBilledAmount().compareTo(BigDecimal.ZERO) <= 0) {
                 log.warn("Removing invalid claim line with procedure code {}: billed amount is null or zero",
                         line.getProcedureCode());
-                claimLines.remove(line); // BUG: ConcurrentModificationException thrown here
+                iterator.remove(); // Safe removal using iterator
             }
         }
 


### PR DESCRIPTION
## Auto-fix: ConcurrentModificationException crashes batch claim processing when invalid claim lines present

### Source files changed
- `src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java`

### References
- Fixes Jira ticket: **KAN-10**

### Code Review — REQUEST CHANGES
**Verdict**: REQUEST CHANGES

**Review comments:**
  - **Incomplete Fix**: Only the import statement for Iterator is shown; the actual `validateClaimLines` method around line 180 where the exception occurs is not provided
  - **Missing Implementation**: Need to see the actual change from for-each loop to Iterator.remove() pattern to verify correctness
  - **Documentation Issue**: The "KNOWN ISSUES" comment still lists Bug #3 as unfixed, contradicting the change rationale
  - **Healthcare Risk**: Cannot assess if the fix properly handles invalid claim lines without removing valid PHI data
  - **Request**: Please provide the complete `validateClaimLines` method showing the before/after iterator implementation to complete the review


> Auto-generated by Developer Agent — please review before merging.