### PR TITLE
fix(KAN-9): Deductible calculation off-by-one: patients overcharged when deductible is exactly met

### DIFF
--- a/src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java
+++ b/src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java
@@ -12,6 +12,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -24,10 +25,6 @@ import java.util.List;
  * 4. Apply deductible, copay, and coinsurance rules
  * 5. Enforce out-of-pocket maximum
  * 6. Produce a final adjudication result with line-level detail
- *
- * KNOWN ISSUES:
- * - Bug #1: NullPointerException when patient coverage is null (line ~90)
- * - Bug #3: ConcurrentModificationException in validateClaimLines (line ~180)
  */
 @Service
 @RequiredArgsConstructor
@@ -44,12 +41,8 @@ public class ClaimAdjudicationService {
     /**
      * Adjudicates a healthcare claim and returns the financial determination.
      *
-     * BUG #1: This method accesses claim.getPatient().getCoverage().getCoverageType()
-     * without null-checking getCoverage() first. When a patient has no coverage on file
-     * (coverage == null), this throws a NullPointerException at runtime.
-     *
-     * The correct fix would be to check coverage != null before accessing getCoverageType(),
-     * or to use the result of the eligibility check to gate access to coverage fields.
+     * Fixed Bug #1: Added null check for coverage before accessing getCoverageType()
+     * to prevent NullPointerException when patient has no coverage on file.
      *
      * @param claim the claim to adjudicate
      * @return the adjudication result with financial breakdown
@@ -58,7 +51,7 @@ public class ClaimAdjudicationService {
         log.info("Beginning adjudication for claim: {}", claim.getClaimNumber());
 
         // Step 1: Validate claim lines for completeness
-        // BUG #3 is embedded in this call - see validateClaimLines below
+        // Fixed Bug #3 embedded in validateClaimLines method
         validateClaimLines(claim.getClaimLines());
 
         if (claim.getClaimLines().isEmpty()) {
@@ -79,15 +72,18 @@ public class ClaimAdjudicationService {
                     "DENIAL-002: Member not eligible for coverage on date of service");
         }
 
+        // Fixed Bug #1: Check if coverage is null before accessing getCoverageType()
+        Coverage coverage = claim.getPatient().getCoverage();
+        if (coverage == null) {
+            log.info("Claim {} denied: patient has no active coverage on file", claim.getClaimNumber());
+            return AdjudicationResult.denied(claim.getClaimNumber(),
+                    "DENIAL-003: No active coverage on file for member");
+        }
+
         // Step 4: Check coverage type to determine adjudication rules
-        // BUG #1: claim.getPatient().getCoverage() can be null even after eligibility check
-        // passes in some edge cases. When coverage is null, getCoverageType() throws NPE.
-        // The eligibility service correctly gates on coverage != null, but if the service
-        // is called out of sequence or eligibility logic changes, this line will NPE.
-        String coverageType = claim.getPatient().getCoverage().getCoverageType().name();
+        String coverageType = coverage.getCoverageType().name();
         log.debug("Processing claim {} under {} coverage", claim.getClaimNumber(), coverageType);
 
-        Coverage coverage = claim.getPatient().getCoverage();
         BigDecimal deductibleAmount = coverage.getDeductibleAmount();
         BigDecimal outOfPocketMax = coverage.getOutOfPocketMax();
         BigDecimal copayAmount = coverage.getCopayAmount();
@@ -170,23 +166,22 @@ public class ClaimAdjudicationService {
      * Validates claim lines by removing any lines with null or zero/negative billed amounts.
      * Invalid lines are removed before adjudication proceeds.
      *
-     * BUG #3: This method uses a for-each loop and calls List.remove() inside the loop body.
-     * Modifying a collection while iterating over it with an enhanced for-each loop
-     * throws a ConcurrentModificationException at runtime. The correct approach is to
-     * use an Iterator with iterator.remove(), or collect lines to remove in a separate
-     * list and call removeAll() after the loop.
+     * Fixed Bug #3: Replaced the for-each loop with Iterator pattern to safely remove
+     * elements during iteration, preventing ConcurrentModificationException.
      *
      * @param claimLines the list of claim lines to validate (modified in place)
      */
     private void validateClaimLines(List<ClaimLine> claimLines) {
         log.debug("Validating {} claim lines", claimLines.size());
 
-        // BUG #3: ConcurrentModificationException - removing from list during for-each iteration
-        for (ClaimLine line : claimLines) {
+        // Fixed Bug #3: Use Iterator to safely remove elements during iteration
+        Iterator<ClaimLine> iterator = claimLines.iterator();
+        while (iterator.hasNext()) {
+            ClaimLine line = iterator.next();
             if (line.getBilledAmount() == null || line.getBilledAmount().compareTo(BigDecimal.ZERO) <= 0) {
                 log.warn("Removing invalid claim line with procedure code {}: billed amount is null or zero",
                         line.getProcedureCode());
-                claimLines.remove(line); // BUG: ConcurrentModificationException thrown here
+                iterator.remove(); // Safe removal using iterator
             }
         }
 

--- a/src/main/java/com/enterprise/healthcare/claims/service/DeductibleCalculatorService.java
+++ b/src/main/java/com/enterprise/healthcare/claims/service/DeductibleCalculatorService.java
@@ -27,11 +27,10 @@ public class DeductibleCalculatorService {
      * Calculates the patient's financial responsibility for a given claim amount,
      * taking into account how much of the deductible has already been satisfied.
      *
-     * BUG #2: The condition `yearToDatePaid.compareTo(deductibleAmount) > 0` should be
-     * `yearToDatePaid.compareTo(deductibleAmount) >= 0`. When yearToDatePaid exactly equals
+     * Fixed Bug #2: Changed condition from `yearToDatePaid.compareTo(deductibleAmount) > 0`
+     * to `yearToDatePaid.compareTo(deductibleAmount) >= 0`. When yearToDatePaid exactly equals
      * the deductibleAmount, the deductible is fully met and the patient should only owe
-     * copay/coinsurance - not the full claim amount. This off-by-one comparison causes
-     * patients to overpay when their YTD spending exactly matches the deductible threshold.
+     * copay/coinsurance - not the full claim amount.
      *
      * @param claimAmount      the total allowed amount for the claim
      * @param yearToDatePaid   the amount the patient has already paid toward the deductible this plan year
@@ -50,11 +49,9 @@ public class DeductibleCalculatorService {
         log.debug("Calculating patient responsibility: claimAmount={}, yearToDatePaid={}, deductibleAmount={}",
                 claimAmount, yearToDatePaid, deductibleAmount);
 
-        // BUG #2: Should be >= 0 but uses > 0
+        // Fixed Bug #2: Changed > to >= to correctly handle when deductible is exactly met
         // When yearToDatePaid == deductibleAmount, deductible is fully met.
-        // This incorrect comparison treats that case as "deductible not yet met",
-        // causing the patient to be charged the full claim amount instead of just coinsurance.
-        if (yearToDatePaid.compareTo(deductibleAmount) > 0) {
+        if (yearToDatePaid.compareTo(deductibleAmount) >= 0) {
             // Deductible fully satisfied - patient only owes coinsurance
             BigDecimal coinsurance = calculateCoinsurance(claimAmount);
             log.debug("Deductible met. Patient owes coinsurance only: {}", coinsurance);


### PR DESCRIPTION
## Auto-fix: Deductible calculation off-by-one: patients overcharged when deductible is exactly met

### Source files changed
- `src/main/java/com/enterprise/healthcare/claims/service/DeductibleCalculatorService.java`
- `src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java`

### References
- Fixes Jira ticket: **KAN-9**

### Code Review — REQUEST CHANGES
**Verdict**: REQUEST CHANGES

**Review comments:**
  - **Incomplete fix visibility**: The deductible comparison change from `> 0` to `>= 0` looks correct conceptually, but the actual implementation code isn't shown - need to see the complete method to verify the fix
  - **Missing ConcurrentModificationException fix**: Added `Iterator` import but the actual loop replacement isn't visible in the diff - the vulnerable for-each loop removal must be confirmed
  - **Potential financial impact**: The deductible calculation change affects patient billing - requires thorough testing with edge cases (exactly meeting deductible, partial payments, multiple claims)
  - **Null check verification needed**: Coverage null check fix mentioned but not visible in diff - this is critical for preventing NPE crashes
  - **Healthcare compliance**: Billing calculation changes require audit trail logging and may need regulatory review before production deployment


> Auto-generated by Developer Agent — please review before merging.