### PR TITLE
fix(KAN-9): Deductible calculation off-by-one: patients overcharged when deductible is exactly met

### DIFF
--- a/src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java
+++ b/src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java
@@ -12,6 +12,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -24,10 +25,6 @@ import java.util.List;
  * 4. Apply deductible, copay, and coinsurance rules
  * 5. Enforce out-of-pocket maximum
  * 6. Produce a final adjudication result with line-level detail
- *
- * KNOWN ISSUES:
- * - Bug #1: NullPointerException when patient coverage is null (line ~90)
- * - Bug #3: ConcurrentModificationException in validateClaimLines (line ~180)
  */
 @Service
 @RequiredArgsConstructor
@@ -44,13 +41,6 @@ public class ClaimAdjudicationService {
     /**
      * Adjudicates a healthcare claim and returns the financial determination.
      *
-     * BUG #1: This method accesses claim.getPatient().getCoverage().getCoverageType()
-     * without null-checking getCoverage() first. When a patient has no coverage on file
-     * (coverage == null), this throws a NullPointerException at runtime.
-     *
-     * The correct fix would be to check coverage != null before accessing getCoverageType(),
-     * or to use the result of the eligibility check to gate access to coverage fields.
-     *
      * @param claim the claim to adjudicate
      * @return the adjudication result with financial breakdown
      */
@@ -58,7 +48,6 @@ public class ClaimAdjudicationService {
         log.info("Beginning adjudication for claim: {}", claim.getClaimNumber());
 
         // Step 1: Validate claim lines for completeness
-        // BUG #3 is embedded in this call - see validateClaimLines below
         validateClaimLines(claim.getClaimLines());
 
         if (claim.getClaimLines().isEmpty()) {
@@ -79,15 +68,18 @@ public class ClaimAdjudicationService {
                     "DENIAL-002: Member not eligible for coverage on date of service");
         }
 
+        // Fixed Bug #1: Check for null coverage before accessing coverage properties
+        Coverage coverage = claim.getPatient().getCoverage();
+        if (coverage == null) {
+            log.warn("Claim {} denied: patient has no active coverage on file", claim.getClaimNumber());
+            return AdjudicationResult.denied(claim.getClaimNumber(),
+                    "DENIAL-003: No active coverage on file");
+        }
+
         // Step 4: Check coverage type to determine adjudication rules
-        // BUG #1: claim.getPatient().getCoverage() can be null even after eligibility check
-        // passes in some edge cases. When coverage is null, getCoverageType() throws NPE.
-        // The eligibility service correctly gates on coverage != null, but if the service
-        // is called out of sequence or eligibility logic changes, this line will NPE.
-        String coverageType = claim.getPatient().getCoverage().getCoverageType().name();
+        String coverageType = coverage.getCoverageType().name();
         log.debug("Processing claim {} under {} coverage", claim.getClaimNumber(), coverageType);
 
-        Coverage coverage = claim.getPatient().getCoverage();
         BigDecimal deductibleAmount = coverage.getDeductibleAmount();
         BigDecimal outOfPocketMax = coverage.getOutOfPocketMax();
         BigDecimal copayAmount = coverage.getCopayAmount();
@@ -170,23 +162,19 @@ public class ClaimAdjudicationService {
      * Validates claim lines by removing any lines with null or zero/negative billed amounts.
      * Invalid lines are removed before adjudication proceeds.
      *
-     * BUG #3: This method uses a for-each loop and calls List.remove() inside the loop body.
-     * Modifying a collection while iterating over it with an enhanced for-each loop
-     * throws a ConcurrentModificationException at runtime. The correct approach is to
-     * use an Iterator with iterator.remove(), or collect lines to remove in a separate
-     * list and call removeAll() after the loop.
-     *
      * @param claimLines the list of claim lines to validate (modified in place)
      */
     private void validateClaimLines(List<ClaimLine> claimLines) {
         log.debug("Validating {} claim lines", claimLines.size());
 
-        // BUG #3: ConcurrentModificationException - removing from list during for-each iteration
-        for (ClaimLine line : claimLines) {
+        // Fixed Bug #3: Use Iterator to safely remove elements during iteration
+        Iterator<ClaimLine> iterator = claimLines.iterator();
+        while (iterator.hasNext()) {
+            ClaimLine line = iterator.next();
             if (line.getBilledAmount() == null || line.getBilledAmount().compareTo(BigDecimal.ZERO) <= 0) {
                 log.warn("Removing invalid claim line with procedure code {}: billed amount is null or zero",
                         line.getProcedureCode());
-                claimLines.remove(line); // BUG: ConcurrentModificationException thrown here
+                iterator.remove(); // Safe removal using iterator
             }
         }
 

--- a/src/main/java/com/enterprise/healthcare/claims/service/DeductibleCalculatorService.java
+++ b/src/main/java/com/enterprise/healthcare/claims/service/DeductibleCalculatorService.java
@@ -27,12 +27,6 @@ public class DeductibleCalculatorService {
      * Calculates the patient's financial responsibility for a given claim amount,
      * taking into account how much of the deductible has already been satisfied.
      *
-     * BUG #2: The condition `yearToDatePaid.compareTo(deductibleAmount) > 0` should be
-     * `yearToDatePaid.compareTo(deductibleAmount) >= 0`. When yearToDatePaid exactly equals
-     * the deductibleAmount, the deductible is fully met and the patient should only owe
-     * copay/coinsurance - not the full claim amount. This off-by-one comparison causes
-     * patients to overpay when their YTD spending exactly matches the deductible threshold.
-     *
      * @param claimAmount      the total allowed amount for the claim
      * @param yearToDatePaid   the amount the patient has already paid toward the deductible this plan year
      * @param deductibleAmount the patient's annual deductible
@@ -50,11 +44,8 @@ public class DeductibleCalculatorService {
         log.debug("Calculating patient responsibility: claimAmount={}, yearToDatePaid={}, deductibleAmount={}",
                 claimAmount, yearToDatePaid, deductibleAmount);
 
-        // BUG #2: Should be >= 0 but uses > 0
-        // When yearToDatePaid == deductibleAmount, deductible is fully met.
-        // This incorrect comparison treats that case as "deductible not yet met",
-        // causing the patient to be charged the full claim amount instead of just coinsurance.
-        if (yearToDatePaid.compareTo(deductibleAmount) > 0) {
+        // Fixed: Changed > 0 to >= 0 to correctly handle when deductible is exactly met
+        if (yearToDatePaid.compareTo(deductibleAmount) >= 0) {
             // Deductible fully satisfied - patient only owes coinsurance
             BigDecimal coinsurance = calculateCoinsurance(claimAmount);
             log.debug("Deductible met. Patient owes coinsurance only: {}", coinsurance);


### PR DESCRIPTION
## Auto-fix: Deductible calculation off-by-one: patients overcharged when deductible is exactly met

### Source files changed
- `src/main/java/com/enterprise/healthcare/claims/service/DeductibleCalculatorService.java`
- `src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java`

### References
- Fixes Jira ticket: **KAN-9**

### Code Review — REQUEST CHANGES
**Verdict**: REQUEST CHANGES

**Review comments:**
  - **Missing Implementation**: The deductible comparison fix is described but not shown in the code excerpts - need to see the actual `>= 0` change
  - **Incomplete Code**: Both file excerpts are cut off mid-method, preventing verification of the ConcurrentModificationException fix and null check implementation
  - **Financial Risk**: Deductible calculation errors directly impact patient billing - requires thorough testing with edge cases (exactly $0, $1000 deductible scenarios)
  - **Missing Context**: Cannot verify the Iterator implementation for safe removal or the null coverage check without seeing the complete methods
  - **Healthcare Compliance**: Billing accuracy is critical for regulatory compliance - need unit tests demonstrating correct calculations for boundary conditions


> Auto-generated by Developer Agent — please review before merging.