### PR TITLE
fix(RTIS-5503): RTIS-5503

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,8 +13,12 @@ spring.datasource.url=jdbc:h2:mem:claimsdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FA
 spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=
-spring.datasource.hikari.connection-timeout=20000
-spring.datasource.hikari.maximum-pool-size=5
+spring.datasource.hikari.connection-timeout=30000
+spring.datasource.hikari.maximum-pool-size=20
+spring.datasource.hikari.minimum-idle=5
+spring.datasource.hikari.idle-timeout=300000
+spring.datasource.hikari.max-lifetime=1800000
+spring.datasource.hikari.leak-detection-threshold=60000
 
 # H2 Console - accessible at http://localhost:8080/h2-console
 spring.h2.console.enabled=true


### PR DESCRIPTION
## Auto-fix: RTIS-5503

### Source files changed
- `src/main/resources/application.properties`

### References
- Fixes Jira ticket: **RTIS-5503**

### Code Review — REQUEST CHANGES
**Verdict**: REQUEST CHANGES

**Review comments:**
  - **Critical Issue**: H2 in-memory DB (`jdbc:h2:mem:`) loses all data on restart - inappropriate for $31,800 claims processing where data persistence is essential
  - **Production Mismatch**: H2 is designed for testing/development; production healthcare systems require persistent databases (PostgreSQL, Oracle, etc.)
  - **Pool Configuration**: New HikariCP settings are reasonable (20 max connections, leak detection), but won't solve underlying architecture problem
  - **Missing Monitoring**: No connection pool metrics configured to detect future exhaustion before it impacts claims processing
  - **Compliance Risk**: Data loss potential violates healthcare audit trail requirements for claims adjudication


> Auto-generated by Developer Agent — please review before merging.