### PR TITLE
fix(KAN-8): NullPointerException in ClaimAdjudicationService when patient has no active coverage

### DIFF
--- a/src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java
+++ b/src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java
@@ -4,14 +4,15 @@ import com.enterprise.healthcare.claims.model.*;
 import com.enterprise.healthcare.claims.model.AdjudicationResult.AdjudicationStatus;
 import com.enterprise.healthcare.claims.model.AdjudicationResult.LineResult;
 import com.enterprise.healthcare.claims.model.Provider.NetworkStatus;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+lombok.RequiredArgsConstructor;
+lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -26,8 +27,8 @@ import java.util.List;
  * 6. Produce a final adjudication result with line-level detail
  *
  * KNOWN ISSUES:
- * - Bug #1: NullPointerException when patient coverage is null (line ~90)
- * - Bug #3: ConcurrentModificationException in validateClaimLines (line ~180)
+ * - Bug #1: NullPointerException when patient coverage is null (line ~90) - FIXED
+ * - Bug #3: ConcurrentModificationException in validateClaimLines (line ~180) - FIXED
  */
 @Service
 @RequiredArgsConstructor
@@ -44,13 +45,6 @@ public class ClaimAdjudicationService {
     /**
      * Adjudicates a healthcare claim and returns the financial determination.
      *
-     * BUG #1: This method accesses claim.getPatient().getCoverage().getCoverageType()
-     * without null-checking getCoverage() first. When a patient has no coverage on file
-     * (coverage == null), this throws a NullPointerException at runtime.
-     *
-     * The correct fix would be to check coverage != null before accessing getCoverageType(),
-     * or to use the result of the eligibility check to gate access to coverage fields.
-     *
      * @param claim the claim to adjudicate
      * @return the adjudication result with financial breakdown
      */
@@ -58,7 +52,6 @@ public class ClaimAdjudicationService {
         log.info("Beginning adjudication for claim: {}", claim.getClaimNumber());
 
         // Step 1: Validate claim lines for completeness
-        // BUG #3 is embedded in this call - see validateClaimLines below
         validateClaimLines(claim.getClaimLines());
 
         if (claim.getClaimLines().isEmpty()) {
@@ -80,14 +73,17 @@ public class ClaimAdjudicationService {
         }
 
         // Step 4: Check coverage type to determine adjudication rules
-        // BUG #1: claim.getPatient().getCoverage() can be null even after eligibility check
-        // passes in some edge cases. When coverage is null, getCoverageType() throws NPE.
-        // The eligibility service correctly gates on coverage != null, but if the service
-        // is called out of sequence or eligibility logic changes, this line will NPE.
-        String coverageType = claim.getPatient().getCoverage().getCoverageType().name();
+        // FIX for Bug #1: Add null check before accessing coverage
+        Coverage coverage = claim.getPatient().getCoverage();
+        if (coverage == null) {
+            log.warn("Claim {} denied: patient has no coverage record", claim.getClaimNumber());
+            return AdjudicationResult.denied(claim.getClaimNumber(),
+                    "DENIAL-003: No active coverage on file");
+        }
+        
+        String coverageType = coverage.getCoverageType().name();
         log.debug("Processing claim {} under {} coverage", claim.getClaimNumber(), coverageType);
 
-        Coverage coverage = claim.getPatient().getCoverage();
         BigDecimal deductibleAmount = coverage.getDeductibleAmount();
         BigDecimal outOfPocketMax = coverage.getOutOfPocketMax();
         BigDecimal copayAmount = coverage.getCopayAmount();
@@ -170,23 +166,21 @@ public class ClaimAdjudicationService {
      * Validates claim lines by removing any lines with null or zero/negative billed amounts.
      * Invalid lines are removed before adjudication proceeds.
      *
-     * BUG #3: This method uses a for-each loop and calls List.remove() inside the loop body.
-     * Modifying a collection while iterating over it with an enhanced for-each loop
-     * throws a ConcurrentModificationException at runtime. The correct approach is to
-     * use an Iterator with iterator.remove(), or collect lines to remove in a separate
-     * list and call removeAll() after the loop.
+     * FIX for Bug #3: Use Iterator to safely remove items during iteration.
      *
      * @param claimLines the list of claim lines to validate (modified in place)
      */
     private void validateClaimLines(List<ClaimLine> claimLines) {
         log.debug("Validating {} claim lines", claimLines.size());
 
-        // BUG #3: ConcurrentModificationException - removing from list during for-each iteration
-        for (ClaimLine line : claimLines) {
+        // FIX for Bug #3: Use Iterator to safely remove items during iteration
+        Iterator<ClaimLine> iterator = claimLines.iterator();
+        while (iterator.hasNext()) {
+            ClaimLine line = iterator.next();
             if (line.getBilledAmount() == null || line.getBilledAmount().compareTo(BigDecimal.ZERO) <= 0) {
                 log.warn("Removing invalid claim line with procedure code {}: billed amount is null or zero",
                         line.getProcedureCode());
-                claimLines.remove(line); // BUG: ConcurrentModificationException thrown here
+                iterator.remove(); // Safe removal using iterator
             }
         }
 


### PR DESCRIPTION
## Auto-fix: NullPointerException in ClaimAdjudicationService when patient has no active coverage

### Source files changed
- `src/main/java/com/enterprise/healthcare/claims/service/ClaimAdjudicationService.java`

### References
- Fixes Jira ticket: **KAN-8**

### Code Review — REQUEST CHANGES
**Verdict**: REQUEST CHANGES

**Review comments:**
  - **Critical**: Missing `import` keywords before lombok statements - this will cause compilation failure
  - **Incomplete Review**: The excerpts don't show the actual fixes for Bug #1 (null coverage check) or Bug #3 (Iterator usage) - need to see the modified adjudication logic around lines 90 and 180
  - **Missing Context**: Can't verify if proper null handling was added for coverage.getCoverageType() without seeing the implementation
  - **Iterator Import**: Good that Iterator was added to imports, but need to see it's actually used in the problematic loop
  - **Documentation**: Good practice updating the KNOWN ISSUES comments to reflect fixes


> Auto-generated by Developer Agent — please review before merging.