### PR TITLE
fix(ST-X): Deductible off-by-one — patient overcharged. Uses > 0 instead of >= 0. When deductible is exactly me

### DIFF
--- a/ClaimAdjudicationService.java:68
+++ b/ClaimAdjudicationService.java:68
@@ -1,0 +1,1 @@
+if (remainingDeductible >= 0) { // Corrected condition to include cases where deductible is exactly met


### PR DESCRIPTION
## Auto-fix by Enterprise Scrum Agent

**Jira:** ST-X
**Bug:** Deductible off-by-one — patient overcharged. Uses > 0 instead of >= 0. When deductible is exactly met, patient is incorrectly charged again.

### Changes
Fixed code in `ClaimAdjudicationService.java:68`