### PR TITLE
fix(ST-1): NullPointerException — no active coverage

### DIFF
--- a/src/main/java/com/hcsc/claims/ClaimAdjudicationService.java
+++ b/src/main/java/com/hcsc/claims/ClaimAdjudicationService.java
@@ -1,0 +1,21 @@
+package com.hcsc.claims;
+
+public class ClaimAdjudicationService {
+
+    public AdjudicationResult adjudicateClaim(Claim claim) {
+        Coverage coverage = coverageRepository
+            .findByMemberId(claim.getMemberId());
+
+        // FIX: Explicit null check before calling isActive()
+        if (coverage == null) {
+            return AdjudicationResult.denied(
+                "No coverage for member: " + claim.getMemberId());
+        }
+
+        if (!coverage.isActive()) {
+            return AdjudicationResult.denied("Inactive coverage");
+        }
+
+        return processActiveClaim(claim, coverage);
+    }
+}


### PR DESCRIPTION
## Auto-fix by Enterprise Scrum Agent

**Jira:** ST-1
**Bug:** NullPointerException — no active coverage

### Changes
Fixed code in `src/main/java/com/hcsc/claims/ClaimAdjudicationService.java`