### PR TITLE
fix(ST-44): NullPointerException — no active coverage check

### DIFF
--- a/src/main/java/com/hcsc/claims/CoreAdjApiWrapper.java
+++ b/src/main/java/com/hcsc/claims/CoreAdjApiWrapper.java
@@ -1,0 +1,3 @@
+Coverage cov = db2Repo.findActiveCoverage(claim.getMbrId());
+if (cov == null) { return AdjResult.denied("No active coverage: " + claim.getMbrId()); }
+if (!cov.isActive()) { return AdjResult.denied("Inactive coverage"); }


### PR DESCRIPTION
## Auto-fix by Enterprise Scrum Agent

**Jira:** ST-44
**Bug:** NullPointerException — no active coverage check

### Changes
Fixed code in `src/main/java/com/hcsc/claims/CoreAdjApiWrapper.java`